### PR TITLE
Referencia de procedencia de Dockerfile

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,3 +1,6 @@
+# Basado en https://github.com/palmoreck/dockerfiles/blob/master/jupyterlab/nvidia/cupy/1.1.0_10.1/Dockerfile
+# Se agregan layers adicionales que permite correr el solver de Markowitz
+
 FROM nvidia/cuda:10.1-devel-ubuntu18.04
 
 ENV JUPYTERLAB_VERSION 1.1.0


### PR DESCRIPTION
Se añade liga al repositorio de donde se tomó el dockefile base del proyecto.

Fixes #47 